### PR TITLE
Fix incorrect x and y positions when canvas size is scaled via CSS

### DIFF
--- a/game/lib/plugins/multitouch.js
+++ b/game/lib/plugins/multitouch.js
@@ -103,12 +103,20 @@ ig.module( 'plugins.multitouch' )
       e.stopPropagation();
       e.preventDefault();
 
+      var internalWidth = parseInt(ig.system.canvas.offsetWidth) || ig.system.realWidth;
+      var scale = ig.system.scale * (internalWidth / ig.system.realWidth);
+
+      var pos = {left: 0, top: 0};
+      if( ig.system.canvas.getBoundingClientRect ) {
+        pos = ig.system.canvas.getBoundingClientRect();
+      }
+
       for ( var i = e.changedTouches.length; i--; ) {
         var t = e.changedTouches[ i ];
 
         this[ 'multi' + e.type ](
-          (t.clientX - ig.system.canvas.offsetLeft) / ig.system.scale,
-          (t.clientY - ig.system.canvas.offsetTop) / ig.system.scale,
+          (t.clientX - pos.left) / scale,
+          (t.clientY - pos.top) / scale,
           t.identifier
         );
       }


### PR DESCRIPTION
These lines are copy-pasted straight from the original `ig.Input.mousemove` function.